### PR TITLE
Added missing comma before "flipover" state in PL translation

### DIFF
--- a/custom_components/neakasa/translations/pl.json
+++ b/custom_components/neakasa/translations/pl.json
@@ -55,7 +55,7 @@
                 "state": {
                     "idle": "Oczekiwanie",
                     "cleaning": "Czyszczenie",
-                    "leveling": "Poziomowanie"
+                    "leveling": "Poziomowanie",
                     "flipover": "Do góry dnem"
                 }
             },

--- a/custom_components/neakasa/translations/pl.json
+++ b/custom_components/neakasa/translations/pl.json
@@ -56,6 +56,7 @@
                     "idle": "Oczekiwanie",
                     "cleaning": "Czyszczenie",
                     "leveling": "Poziomowanie"
+                    "flipover": "Do góry dnem"
                 }
             },
             "sand_state": {

--- a/custom_components/neakasa/translations/pl.json
+++ b/custom_components/neakasa/translations/pl.json
@@ -60,7 +60,7 @@
                 }
             },
             "sand_state": {
-                "name": "Poziom żwirku",
+                "name": "Stan żwirku",
                 "state": {
                     "insufficient": "Niewystarczający",
                     "moderate": "Umiarkowany",


### PR DESCRIPTION
My bad, I edited the file on my phone for PR and (properly) on my HA server, just pulled the latest release and found out.