### PR TITLE
Cache calls

### DIFF
--- a/custom_components/neakasa/coordinator.py
+++ b/custom_components/neakasa/coordinator.py
@@ -16,10 +16,10 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 from datetime import datetime
 
 from .api import NeakasaAPI, APIAuthError, APIConnectionError
+from .value_cacher import ValueCacher
 from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
-
 
 @dataclass
 class NeakasaAPIData:
@@ -42,79 +42,6 @@ class NeakasaAPIData:
     lastUse: int
     cat_list: list[object] = field(default_factory=list)
     record_list: list[object] = field(default_factory=list)
-    statistics: list[object] = field(default_factory=list)
-
-class ValueCacher:
-    def __init__(self, refresh_after: Optional[timedelta], discard_after: Optional[timedelta]):
-        """
-        :param refresh_after:
-            How long to wait before considering the cached value stale and needing refresh.
-            - None: value never considered stale
-            - timedelta <= 0: always considered stale
-            - > 0: value is stale after this duration
-
-        :param discard_after:
-            How long to keep the cached value before discarding it entirely.
-            - None: value never discarded (always acceptable as fallback)
-            - timedelta <= 0: value is immediately discarded
-            - > 0: value is discarded after this duration
-        """
-        self._refresh_after = refresh_after
-        self._discard_after = discard_after
-        self._value: Optional[Any] = None
-        self._last_update: Optional[datetime] = None
-
-    def set(self, value: Any) -> None:
-        self._value = value
-        self._last_update = datetime.utcnow()
-
-    def clear(self) -> None:
-        self._value = None
-        self._last_update = None
-
-    def value_if_not_stale(self) -> Optional[Any]:
-        """
-        Return the value only if it is still fresh (not past refresh_after).
-        Useful when you want to use cached data only if it's up-to-date.
-        """
-        if self._value is None or self._last_update is None:
-            return None
-        if self._refresh_after is not None:
-            if self._refresh_after <= timedelta(0):
-                return None
-            if datetime.utcnow() - self._last_update > self._refresh_after:
-                return None
-        return self._value
-
-    def value_if_not_discarded(self) -> Optional[Any]:
-        """
-        Return the value only if it hasn't been discarded.
-        Discarding is based on discard_after.
-        """
-        if self._value is None or self._last_update is None:
-            return None
-        if self._discard_after is not None:
-            if self._discard_after <= timedelta(0):
-                return None
-            if datetime.utcnow() - self._last_update > self._discard_after:
-                return None
-        return self._value
-
-    async def get_or_update(self, update_func: Callable[[], Awaitable[Any]]) -> Any:
-        """
-        Return cached value if not stale. Otherwise, call `update_func` to get new value.
-        If update fails, returns cached value if not discarded. Otherwise raises the error.
-        """
-        if (value := self.value_if_not_stale()) is not None:
-            return value
-        try:
-            new_value = await update_func()
-            self.set(new_value)
-            return new_value
-        except Exception as err:
-            if (fallback := self.value_if_not_discarded()) is not None:
-                return fallback
-            raise err
 
 class NeakasaCoordinator(DataUpdateCoordinator):
     """My coordinator."""
@@ -131,8 +58,8 @@ class NeakasaCoordinator(DataUpdateCoordinator):
         self.password = config_entry.data[CONF_PASSWORD]
 
         self._deviceName = None
+        self.lastUseDate = None
 
-        self._statisticsCache = ValueCacher(refresh_after=timedelta(minutes=60), discard_after=timedelta(hours=7))
         self._recordsCache = ValueCacher(refresh_after=timedelta(minutes=30), discard_after=timedelta(hours=4))
         self._devicePropertiesCache = ValueCacher(refresh_after=timedelta(seconds=0), discard_after=timedelta(minutes=30))
 
@@ -182,14 +109,6 @@ class NeakasaCoordinator(DataUpdateCoordinator):
         self._deviceName = deviceName
         return deviceName
 
-    async def _getStatistics(self):
-        async def fetch():
-            await self.api.connect(self.username, self.password)
-            deviceName = await self._getDeviceName()
-            return await self.api.getStatistics(deviceName)
-
-        return await self._statisticsCache.get_or_update(fetch)
-
     async def _getRecords(self):
         async def fetch():
             await self.api.connect(self.username, self.password)
@@ -212,9 +131,17 @@ class NeakasaCoordinator(DataUpdateCoordinator):
         so entities can quickly look up their data.
         """
         try:
-            statistics = await self._getStatistics()
-            records = await self._getRecords()
             devicedata = await self._getDeviceProperties()
+
+            newLastUseDate = devicedata['catLeft']['time']
+
+            if self.lastUseDate != newLastUseDate:
+                self._recordsCache.mark_as_stale()
+
+            self.lastUseDate = newLastUseDate
+            
+            records = await self._getRecords()
+
             try:
                 return NeakasaAPIData(
                     binFullWaitReset=devicedata['binFullWaitReset']['value'] == 1, #-> Abfalleimer voll
@@ -231,12 +158,10 @@ class NeakasaCoordinator(DataUpdateCoordinator):
                     room_of_bin=devicedata['room_of_bin']['value'], #-> Abfalleimer [2=nicht in Position,0=Normal]
                     sandLevelState=devicedata['Sand']['value']['level'], #-> Katzenstreu [0=Unzureichend,1=Mäßig,2=Ausreichend]
                     stayTime=devicedata['catLeft']['value']['stayTime'],
-                    lastUse=devicedata['catLeft']['time'],
+                    lastUse=newLastUseDate,
 
                     cat_list=records['cat_list'],
-                    record_list=records['record_list'],
-
-                    statistics=statistics
+                    record_list=records['record_list']
                 )
             except Exception as err:
                 _LOGGER.error(err)

--- a/custom_components/neakasa/coordinator.py
+++ b/custom_components/neakasa/coordinator.py
@@ -58,6 +58,8 @@ class NeakasaCoordinator(DataUpdateCoordinator):
         self.username = config_entry.data[CONF_USERNAME]
         self.password = config_entry.data[CONF_PASSWORD]
 
+        self._deviceName = None
+
         # Initialise DataUpdateCoordinator
         super().__init__(
             hass,
@@ -91,13 +93,18 @@ class NeakasaCoordinator(DataUpdateCoordinator):
         raise Exception('cannot find service to invoke')
 
     async def _getDeviceName(self):
+        if self._deviceName is not None:
+            return self._deviceName
+
         """get deviceName by iotId"""
         await self.api.connect(self.username, self.password)
         devices = await self.api.getDevices()
         devices = list(filter(lambda devices: devices['iotId'] == self.deviceid, devices))
         if(len(devices) == 0):
             raise APIConnectionError("iotId not found in device list")
-        return devices[0]['deviceName']
+        deviceName = devices[0]['deviceName']
+        self._deviceName = deviceName
+        return deviceName
 
     async def async_update_data(self):
         """Fetch data from API endpoint.

--- a/custom_components/neakasa/value_cacher.py
+++ b/custom_components/neakasa/value_cacher.py
@@ -1,0 +1,92 @@
+from dataclasses import dataclass, field
+from datetime import timedelta
+import logging
+from typing import Optional, Any, Awaitable, Callable
+
+from datetime import datetime
+
+from .value_cacher import ValueCacher
+
+_LOGGER = logging.getLogger(__name__)
+
+class ValueCacher:
+    def __init__(self, refresh_after: Optional[timedelta], discard_after: Optional[timedelta]):
+        """
+        :param refresh_after:
+            How long to wait before considering the cached value stale and needing refresh.
+            - None: value never considered stale
+            - timedelta <= 0: always considered stale
+            - > 0: value is stale after this duration
+
+        :param discard_after:
+            How long to keep the cached value before discarding it entirely.
+            - None: value never discarded (always acceptable as fallback)
+            - timedelta <= 0: value is immediately discarded
+            - > 0: value is discarded after this duration
+        """
+        self._refresh_after = refresh_after
+        self._discard_after = discard_after
+
+        self._manually_marked_stale = False
+
+        self._value: Optional[Any] = None
+        self._last_update: Optional[datetime] = None
+
+    def set(self, value: Any) -> None:
+        self._value = value
+        self._last_update = datetime.utcnow()
+        self._manually_marked_stale = False
+
+    def clear(self) -> None:
+        self._value = None
+        self._last_update = None
+		self._manually_marked_stale = False
+
+    def mark_as_stale(self) -> None:
+		self._manually_marked_stale = true
+
+    def value_if_not_stale(self) -> Optional[Any]:
+        """
+        Return the value only if it is still fresh (not past refresh_after).
+        Useful when you want to use cached data only if it's up-to-date.
+        """
+        if self._manually_marked_stale:
+        	return None
+        if self._value is None or self._last_update is None:
+            return None
+        if self._refresh_after is not None:
+            if self._refresh_after <= timedelta(0):
+                return None
+            if datetime.utcnow() - self._last_update > self._refresh_after:
+                return None
+        return self._value
+
+    def value_if_not_discarded(self) -> Optional[Any]:
+        """
+        Return the value only if it hasn't been discarded.
+        Discarding is based on discard_after.
+        """
+        if self._value is None or self._last_update is None:
+            return None
+        if self._discard_after is not None:
+            if self._discard_after <= timedelta(0):
+                return None
+            if datetime.utcnow() - self._last_update > self._discard_after:
+                return None
+        return self._value
+
+    async def get_or_update(self, update_func: Callable[[], Awaitable[Any]]) -> Any:
+        """
+        Return cached value if not stale. Otherwise, call `update_func` to get new value.
+        If update fails, returns cached value if not discarded. Otherwise raises the error.
+        """
+        if (value := self.value_if_not_stale()) is not None:
+            return value
+        try:
+            new_value = await update_func()
+            self.set(new_value)
+            return new_value
+        except Exception as err:
+            if (fallback := self.value_if_not_discarded()) is not None:
+                return fallback
+            raise err

--- a/custom_components/neakasa/value_cacher.py
+++ b/custom_components/neakasa/value_cacher.py
@@ -5,8 +5,6 @@ from typing import Optional, Any, Awaitable, Callable
 
 from datetime import datetime
 
-from .value_cacher import ValueCacher
-
 _LOGGER = logging.getLogger(__name__)
 
 class ValueCacher:
@@ -43,7 +41,7 @@ class ValueCacher:
         self._manually_marked_stale = False
 
     def mark_as_stale(self) -> None:
-        self._manually_marked_stale = true
+        self._manually_marked_stale = True
 
     def value_if_not_stale(self) -> Optional[Any]:
         """

--- a/custom_components/neakasa/value_cacher.py
+++ b/custom_components/neakasa/value_cacher.py
@@ -40,10 +40,10 @@ class ValueCacher:
     def clear(self) -> None:
         self._value = None
         self._last_update = None
-		self._manually_marked_stale = False
+        self._manually_marked_stale = False
 
     def mark_as_stale(self) -> None:
-		self._manually_marked_stale = true
+        self._manually_marked_stale = true
 
     def value_if_not_stale(self) -> Optional[Any]:
         """
@@ -51,7 +51,7 @@ class ValueCacher:
         Useful when you want to use cached data only if it's up-to-date.
         """
         if self._manually_marked_stale:
-        	return None
+            return None
         if self._value is None or self._last_update is None:
             return None
         if self._refresh_after is not None:


### PR DESCRIPTION
Cache calls to reduce the number of calls made and to handle errors better.
Changes:
- `getDevices`: is called only once, as the device shouldn't change
- `getStatistics`: is cached and called less often (but is it used?)
- `getRecords`: is cached and called less often
- `getdeviceProperties`: is cached and can fall back to the previous value if the call fails. I had an issue where the entities would sometimes become unavailable for short periods of time. Caching the value, should help with this.