### PR TITLE
Add support for "auto clean" switch

### DIFF
--- a/custom_components/neakasa/coordinator.py
+++ b/custom_components/neakasa/coordinator.py
@@ -26,6 +26,7 @@ class NeakasaAPIData:
     """Class to hold api data."""
 
     binFullWaitReset: bool
+    cleanCfg: dict[str, Any]
     sandLevelState: int
     sandLevelPercent: int
     bucketStatus: int
@@ -79,7 +80,7 @@ class NeakasaCoordinator(DataUpdateCoordinator):
         self.api = NeakasaAPI(session, hass.async_add_executor_job)
         
 
-    async def setProperty(self, key: str, value: int):
+    async def setProperty(self, key: str, value: Any):
         await self.api.connect(self.username, self.password)
         await self.api.setDeviceProperties(self.deviceid, {key: value})
         #update data
@@ -132,7 +133,7 @@ class NeakasaCoordinator(DataUpdateCoordinator):
         """
         try:
             devicedata = await self._getDeviceProperties()
-
+            
             newLastUseDate = devicedata['catLeft']['time']
 
             if self.lastUseDate != newLastUseDate:
@@ -145,6 +146,7 @@ class NeakasaCoordinator(DataUpdateCoordinator):
             try:
                 return NeakasaAPIData(
                     binFullWaitReset=devicedata['binFullWaitReset']['value'] == 1, #-> Abfalleimer voll
+                    cleanCfg=devicedata['cleanCfg']['value'],
                     youngCatMode=devicedata['youngCatMode']['value'] == 1, #-> Kätzchen Modus
                     childLockOnOff=devicedata['childLockOnOff']['value'] == 1, #-> Kindersicherung
                     autoBury=devicedata['autoBury']['value'] == 1, #-> automatische Abdeckung

--- a/custom_components/neakasa/translations/de.json
+++ b/custom_components/neakasa/translations/de.json
@@ -38,6 +38,9 @@
             }
         },
         "sensor": {
+            "auto_clean": {
+                "name": "Auto-Rein"
+            },
             "cat_sensor": {
                 "name": "Katze {name}"
             },

--- a/custom_components/neakasa/translations/de.json
+++ b/custom_components/neakasa/translations/de.json
@@ -39,7 +39,7 @@
         },
         "sensor": {
             "auto_clean": {
-                "name": "Auto-Rein"
+                "name": "Automatische Reinigung"
             },
             "cat_sensor": {
                 "name": "Katze {name}"

--- a/custom_components/neakasa/translations/en.json
+++ b/custom_components/neakasa/translations/en.json
@@ -82,6 +82,9 @@
             }
         },
         "switch": {
+            "auto_clean": {
+                "name": "Auto clean"
+            },
             "young_cat_mode": {
                 "name": "Kitten mode"
             },

--- a/custom_components/neakasa/translations/pl.json
+++ b/custom_components/neakasa/translations/pl.json
@@ -82,6 +82,9 @@
             }
         },
         "switch": {
+            "auto_clean": {
+                "name": "Auto czysz"
+            },
             "young_cat_mode": {
                 "name": "Tryb dla kociąt"
             },

--- a/custom_components/neakasa/translations/pl.json
+++ b/custom_components/neakasa/translations/pl.json
@@ -83,7 +83,7 @@
         },
         "switch": {
             "auto_clean": {
-                "name": "Auto czysz"
+                "name": "Automatyczne czyszczenie"
             },
             "young_cat_mode": {
                 "name": "Tryb dla kociąt"


### PR DESCRIPTION
This PR adds an `auto clean` switch that allows Home Assistant to toggle it `on` and `off`.

`cleanCfg` when it is set to clean after `10` minute(s):
```
'cleanCfg': {
	'time': 1745434522949,
	'value': {
		'cleanType': 1,
		'cleanParam': 10,
		'active': 1
	}
},
```
`cleanCfg` when it is set to clean every `1` hour(s):
```
'cleanCfg': {
	'time': 1745475625700,
	'value': {
		'cleanType': 2,
		'cleanParam': 1,
		'active': 1
	}
},
```